### PR TITLE
Improve Wayland support

### DIFF
--- a/code.sh
+++ b/code.sh
@@ -16,7 +16,7 @@ if [ ! -f ${FIRST_RUN} ]; then
 fi
 
 if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
-  WAYLAND_OPTS="--ozone-platform-hint=auto"
+  WAYLAND_OPTS="--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations"
 fi
 
 PYTHON_SITEDIR=$(python3 <<EOFPYTHON

--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -11,7 +11,7 @@ separate-locales: false
 finish-args:
   - --require-version=0.10.3
   - --share=ipc
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=wayland
   - --socket=pulseaudio
   - --socket=ssh-auth


### PR DESCRIPTION
This enables WaylandWindowDecorations for CSD only compositors and enables x11 socket only for when needed.